### PR TITLE
Fix license name for the dataset

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ library(vacancesscolr)
 
 The goal of `vacancesscolr` is to be able to quickly retrieve school holidays in France for the 2008-2018 period.
 
-The data used in this package has been obtained from [Antoine Augusti's vacances-scolaires dataset](https://github.com/AntoineAugusti/vacances-scolaires), under MIT license.
+The data used in this package has been obtained from [Antoine Augusti's vacances-scolaires dataset](https://github.com/AntoineAugusti/vacances-scolaires), under the Etalab license (open license).
 
 ## Installation
 


### PR DESCRIPTION
Hello!

Thanks a lot for creating this R package. The dataset is available under the Etalab license but the pip package is under the MIT one.

Therefore, I've fixed the README.